### PR TITLE
Use empty string instead of undefined in server id

### DIFF
--- a/src/Network/PushNotify/APN.hs
+++ b/src/Network/PushNotify/APN.hs
@@ -507,7 +507,7 @@ newConnection aci = do
     clip <- case (aciUseJWT aci) of
         True -> do
           castore <- getSystemCertificateStore
-          let clip = (defaultParamsClient (T.unpack hostname) undefined)
+          let clip = (defaultParamsClient (T.unpack hostname) "")
                   { clientUseMaxFragmentLength=Nothing
                   , clientUseServerNameIndication=True
                   , clientWantSessionResume=Nothing
@@ -534,7 +534,7 @@ newConnection aci = do
               shared      = def { sharedCredentials = credentials
                                 , sharedCAStore=castore }
 
-              clip = (defaultParamsClient (T.unpack hostname) undefined)
+              clip = (defaultParamsClient (T.unpack hostname) "")
                   { clientUseMaxFragmentLength=Nothing
                   , clientUseServerNameIndication=True
                   , clientWantSessionResume=Nothing


### PR DESCRIPTION
It seems the TLS upgrade caused undefined to get evaluated resulting in breakage on push notifications. Updates to use the empty string instead which should bring us in line with previous behavior